### PR TITLE
Add reverse lookup and scalar filters

### DIFF
--- a/inc/points_builder.h
+++ b/inc/points_builder.h
@@ -25,13 +25,21 @@ extern "C" {
 // Public API
 // Don't include or use other lib headers here.
 
+typedef struct scalar_filter_s {
+    int prime_only;
+    int triangular_only;
+    U64 modulo;
+    int use_modulo;
+} scalar_filter_t;
+
 int pointsBuilderGenerate(
     const char * baseKey,
     uint64_t rangeSize,
     uint32_t numLoopsPerThread,
     uint16_t numThreads,
     uint32_t progressMinInterval,
-    const char * dbName
+    const char * dbName,
+    const scalar_filter_t * filter
 );
 
 #ifdef __cplusplus

--- a/src/lib/db.h
+++ b/src/lib/db.h
@@ -30,4 +30,9 @@ void db_insert_result(
     U8 yParity
 );
 
+int db_lookup_scalar(
+    const U8 * x,
+    U64 * scalar
+);
+
 #endif // POINTS_BUILDER_DB_H

--- a/src/lib/ge_batch_addition.h
+++ b/src/lib/ge_batch_addition.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <secp256k1.h>
 
 #include "../common_def.h"
+#include "../../inc/points_builder.h"     // scalar_filter_t
 
 #define NUM_CONST_POINTS    512
 
@@ -37,7 +38,8 @@ int batch_add_range(
     mpz_srcptr baseKey,
     const secp256k1_ge * base_ge,
     on_result_cb callback,
-    U32 progressMinInterval
+    U32 progressMinInterval,
+    const scalar_filter_t * filter
 );
 
 #endif // POINTS_BUILDER_GE_BATCH_ADD_H

--- a/src/lib/points_builder.c
+++ b/src/lib/points_builder.c
@@ -212,7 +212,8 @@ int pointsBuilderGenerate(
     U32 numLoopsPerThread,
     U16 numThreads,
     U32 progressMinInterval,
-    const char * dbName
+    const char * dbName,
+    const scalar_filter_t * filter
 ) {
     secp256k1_context * ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
 
@@ -271,7 +272,8 @@ int pointsBuilderGenerate(
         ctx, numLaunches, numLoopsPerThread, numThreads,
         useBasePub ? NULL : mpBaseKey,
         useBasePub ? &base_ge: NULL,
-        result_cb, progressMinInterval
+        result_cb, progressMinInterval,
+        filter
     );
 
     double ompEndTime = omp_get_wtime();


### PR DESCRIPTION
## Summary
- enable scalar filtering via `prime-only`, `triangular-only` and `modulo` options
- implement database reverse lookup of a point's X value
- plumb filtering and lookup flags through CLI and library APIs
- gate result insertion on new scalar filter logic

## Testing
- `cmake -S . -B build` *(fails: gmp not found)*

------
https://chatgpt.com/codex/tasks/task_e_68427b1e6c248326950fb9bc527304b7